### PR TITLE
build and deploy workflow runs on develop branch

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
 jobs:
 
   run_tests:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
+[![CI/CD](https://github.com/ivartm/bbbs/actions/workflows/build_and_deploy.yml/badge.svg)](https://github.com/ivartm/bbbs/actions/workflows/build_and_deploy.yml)
+[![tests](https://github.com/ivartm/bbbs/actions/workflows/tests.yml/badge.svg)](https://github.com/ivartm/bbbs/actions/workflows/tests.yml)
 ![pep8 codestyle](https://github.com/ivartm/bbbs/actions/workflows/codestyle.yml/badge.svg)
 
-[![afisha app tests](https://github.com/ivartm/bbbs/actions/workflows/tests.yml/badge.svg)](https://github.com/ivartm/bbbs/actions/workflows/tests.yml)
 
 # bbbs
 Бэкенд для проекта Старшие Братья Старшие Сестры https://www.nastavniki.org/

--- a/production.yaml
+++ b/production.yaml
@@ -14,9 +14,6 @@ services:
       - ./.envs/.prod/.postgres
   django:
     image: klyaxa/bbbs-backend:latest
-    build:
-      context: .
-      dockerfile: ./compose/production/django/Dockerfile
     restart: always
     volumes:
       - static_value:/code/staticfiles/


### PR DESCRIPTION
1. Теперь CI/CD применим для ветки **develop**
2. Теперь контейнер с приложением не собирается на сервере, а забирается с hub.docker (предварительно туда загружается)
3. Обновил README и добавил CI/CD badge